### PR TITLE
Skip loading submodules from nonexistent file

### DIFF
--- a/private/loader.rkt
+++ b/private/loader.rkt
@@ -59,6 +59,12 @@
            ;; must not load at all (w/o complaint)
            (log-custom-load-info "skipping (zo submod request) ~s" file)
            (void)]
+          [(and (pair? name) (car name) (not (file-exists? file)))
+           ;; the default use-compiled handler ``failed'' silently
+           ;; when requested for submodules in a nonexistent file.
+           (log-custom-load-info "skipping submod ~a in nonexistent file ~s"
+                                 name file)
+           (void)]
           [else
            (log-custom-load-info "using source for ~s" file)
            (parameterize ((current-load-relative-directory (path-only file)))


### PR DESCRIPTION
The default compiled-load handler, when requested to load submodules from non-existent files, will fail silently. However, the default load handler will raise an exception. This commit stops the custom loader from handing such load requests to the default load handler.

- The behavior of the default compiled-load handler <https://github.com/racket/racket/blob/master/racket/src/racket/src/startup.rktl#L1190>

- A relevant test case (I'm not sure where to place this test)

```racket
#lang racket/base

(require syntax/modread custom-load)

(parameterize ([current-namespace (make-base-namespace)]
               [current-load/use-compiled (make-custom-load/use-compiled
                                           #:blacklist (λ (_) #t))])
  ; will try to load s-exp/main.rkt which does not exist
  (with-module-reading-parameterization
      (λ () (read-syntax #f (open-input-string "#lang s-exp '#%kernel\n")))))
```